### PR TITLE
fix: update web_browsing link

### DIFF
--- a/pkg/agents/agents.go
+++ b/pkg/agents/agents.go
@@ -23,8 +23,7 @@ const (
 )
 
 var builtInFunctionNameToDefinition = map[string]ToolDefinition{
-	// Skipping the loading of the web_search tool because it is currently not working.
-	"web_browsing": {Link: "github.com/gptscript-ai/question-answerer", SubTool: "question-answerer-ddg"},
+	"web_browsing": {Link: "github.com/gptscript-ai/question-answerer/duckduckgo"},
 	// TODO(thedadams): This will be moved to gptscript-ai in the future.
 	"code_interpreter": {Link: "github.com/thedadams/code-interpreter"},
 }


### PR DESCRIPTION
The question-answerer tool used for built-in web_browsing support has been changed s.t. its subtools now live in separate subdirectories as standalone tools, changing their import path and usage. This prevents clicky-chats from loading the duckduckgo subtool at startup.

To fix this, change the `ToolDefinition` for web_browsing to import the question-answerer/duckduckgo tool.

Note: The new question-answerer/duckduckgo tool also uses the new subdirectory-based import paths for the updated search tool as well.