### PR TITLE
fix: disable revive for channel drain

### DIFF
--- a/pkg/agents/agents.go
+++ b/pkg/agents/agents.go
@@ -185,6 +185,7 @@ func sendChunk(ctx context.Context, stream chan db.ChatCompletionResponseChunk, 
 	select {
 	case <-ctx.Done():
 		go func() {
+			//nolint:revive
 			for range stream {
 			}
 		}()


### PR DESCRIPTION
Disable revive linting for the channel drain code-block. It's intentionally empty and shouldn't cause the validate action from failing.