### PR TITLE
fix: remove https:// from github tools

### DIFF
--- a/pkg/server/tools.go
+++ b/pkg/server/tools.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/acorn-io/z"
 	"github.com/gptscript-ai/clicky-chats/pkg/db"
@@ -19,6 +20,10 @@ func toolToProgram(ctx context.Context, tool *db.Tool) ([]byte, error) {
 	)
 
 	if url := z.Dereference(tool.URL); url != "" {
+		if !strings.HasSuffix(url, ".gpt") {
+			url = strings.TrimPrefix(strings.TrimPrefix(url, "https://"), "http://")
+			tool.URL = &url
+		}
 		prg, err = loader.Program(ctx, url, z.Dereference(tool.Subtool))
 		if err != nil {
 			err = NewAPIError(fmt.Sprintf("failed parsing request object: %v", err), InvalidRequestErrorType)


### PR DESCRIPTION
GPTScript expects GitHub tools to start with github.com and not https://. This change will remove the protocol when necessary.