### PR TITLE
fix: only query for run steps that are in progress

### DIFF
--- a/pkg/agents/steprunner/step_runner.go
+++ b/pkg/agents/steprunner/step_runner.go
@@ -174,7 +174,13 @@ func (a *agent) run(ctx context.Context, runner *runner.Runner) (err error) {
 			return fmt.Errorf("thread %s found to be locked by %s while processing run %s", run.ThreadID, thread.LockedByRunID, run.ID)
 		}
 
-		if err := tx.Model(runStep).Where("run_id = ?", run.ID).Where("type = ?", openai.RunStepObjectTypeToolCalls).Where("runner_type = ?", tools.GPTScriptRunnerType).Order("created_at asc").First(runStep).Error; err != nil {
+		if err := tx.Model(runStep).
+			Where("run_id = ?", run.ID).
+			Where("status = ?", openai.InProgress).
+			Where("type = ?", openai.RunStepObjectTypeToolCalls).
+			Where("runner_type = ?", tools.GPTScriptRunnerType).
+			Order("created_at asc").
+			First(runStep).Error; err != nil {
 			return err
 		}
 


### PR DESCRIPTION
If a run has multiple steps, then it will never complete because the query would always pull the first run step regardless of its status.

After this change, we will pull the first run step in the in_progress status and leave the completed ones alone.