### PR TITLE
fix: timeout tool calls after one minute

### DIFF
--- a/pkg/agents/run/chatcompletion.go
+++ b/pkg/agents/run/chatcompletion.go
@@ -129,7 +129,7 @@ func createChatMessageFromToolOutput(toolOutput openai.RunStepObject_StepDetails
 	messages := make([]openai.ChatCompletionRequestMessage, 1, len(toolCall.ToolCalls)+1)
 	am := new(openai.ChatCompletionRequestMessage)
 	for _, output := range toolCall.ToolCalls {
-		toolInfo, err := db.GetOutputForRunStepToolCall(output)
+		toolInfo, err := db.GetOutputForRunStepToolCall(&output)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/db/runstep.go
+++ b/pkg/db/runstep.go
@@ -311,7 +311,7 @@ func SetOutputForRunStepToolCall(item *openai.RunStepDetailsToolCallsObject_Tool
 	return fmt.Errorf("failed to extract tool call item")
 }
 
-func GetOutputForRunStepToolCall(item openai.RunStepDetailsToolCallsObject_ToolCalls_Item) (GenericToolCallInfo, error) {
+func GetOutputForRunStepToolCall(item *openai.RunStepDetailsToolCallsObject_ToolCalls_Item) (GenericToolCallInfo, error) {
 	info := GenericToolCallInfo{}
 	if tc, err := item.AsRunStepDetailsToolCallsFunctionObject(); err == nil && tc.Type == openai.RunStepDetailsToolCallsFunctionObjectTypeFunction {
 		info.ID = tc.Id

--- a/pkg/db/runstepdelta.go
+++ b/pkg/db/runstepdelta.go
@@ -38,7 +38,7 @@ func (r *RunStepDelta) FromPublic(obj any) error {
 	return nil
 }
 
-func EmitRunStepDeltaOutputEvent(gbd *gorm.DB, run *Run, toolCall openai.RunStepDetailsToolCallsObject_ToolCalls_Item, index int) error {
+func EmitRunStepDeltaOutputEvent(gbd *gorm.DB, run *Run, toolCall *openai.RunStepDetailsToolCallsObject_ToolCalls_Item, index int) error {
 	deltaToolCalls, err := extractToolCallOutputToDeltaToolCall(toolCall, index)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func EmitRunStepDeltaOutputEvent(gbd *gorm.DB, run *Run, toolCall openai.RunStep
 	return nil
 }
 
-func extractToolCallOutputToDeltaToolCall(toolCall openai.RunStepDetailsToolCallsObject_ToolCalls_Item, index int) (*openai.XRunStepDeltaObjectDeltaToolCalls_ToolCalls_Item, error) {
+func extractToolCallOutputToDeltaToolCall(toolCall *openai.RunStepDetailsToolCallsObject_ToolCalls_Item, index int) (*openai.XRunStepDeltaObjectDeltaToolCalls_ToolCalls_Item, error) {
 	deltaToolCalls := new(openai.XRunStepDeltaObjectDeltaToolCalls_ToolCalls_Item)
 	info, err := GetOutputForRunStepToolCall(toolCall)
 	if err != nil {


### PR DESCRIPTION
This will protect against broken tools, for example, getting the content of a Trip Advisor link.