### PR TITLE
feat: add triggering to speed up job processing

### DIFF
--- a/pkg/agents/audio/transcriptions.go
+++ b/pkg/agents/audio/transcriptions.go
@@ -128,5 +128,7 @@ func (a *agent) runTranscriptions(ctx context.Context) error {
 		l.Error("failed to store transcription response", "err", err)
 	}
 
+	a.trigger.Ready(transcriptionRequest.ID)
+
 	return nil
 }

--- a/pkg/agents/audio/translations.go
+++ b/pkg/agents/audio/translations.go
@@ -110,5 +110,7 @@ func (a *agent) runTranslations(ctx context.Context) error {
 		l.Error("failed to store translation response", "err", err)
 	}
 
+	a.trigger.Ready(translationRequest.ID)
+
 	return nil
 }

--- a/pkg/agents/image/edits.go
+++ b/pkg/agents/image/edits.go
@@ -135,5 +135,7 @@ func (a *agent) runEdits(ctx context.Context) error {
 		l.Error("failed to store image edit response", "err", err)
 	}
 
+	a.trigger.Ready(editRequest.ID)
+
 	return nil
 }

--- a/pkg/agents/image/generations.go
+++ b/pkg/agents/image/generations.go
@@ -70,5 +70,7 @@ func (a *agent) runGenerations(ctx context.Context) error {
 		l.Error("failed to store image create response", "err", err)
 	}
 
+	a.trigger.Ready(createRequest.ID)
+
 	return nil
 }

--- a/pkg/agents/image/image.go
+++ b/pkg/agents/image/image.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gptscript-ai/clicky-chats/pkg/db"
+	"github.com/gptscript-ai/clicky-chats/pkg/trigger"
 	"gorm.io/gorm"
 )
 
@@ -31,6 +32,7 @@ func Start(ctx context.Context, gdb *db.DB, cfg Config) error {
 type Config struct {
 	PollingInterval, RetentionPeriod time.Duration
 	ImagesBaseURL, APIKey, AgentID   string
+	Trigger                          trigger.Trigger
 }
 
 type agent struct {
@@ -39,6 +41,7 @@ type agent struct {
 	generationsURL, editsURL, variationsURL string
 	client                                  *http.Client
 	db                                      *db.DB
+	trigger                                 trigger.Trigger
 }
 
 func newAgent(db *db.DB, cfg Config) (*agent, error) {
@@ -47,6 +50,11 @@ func newAgent(db *db.DB, cfg Config) (*agent, error) {
 	}
 	if cfg.RetentionPeriod < minRequestRetention {
 		return nil, fmt.Errorf("[image] request retention must be at least %s", minRequestRetention)
+	}
+
+	if cfg.Trigger == nil {
+		slog.Warn("[image] No trigger provided, using noop")
+		cfg.Trigger = trigger.NewNoop()
 	}
 
 	return &agent{
@@ -59,6 +67,7 @@ func newAgent(db *db.DB, cfg Config) (*agent, error) {
 		apiKey:           cfg.APIKey,
 		db:               db,
 		id:               cfg.AgentID,
+		trigger:          cfg.Trigger,
 	}, nil
 }
 
@@ -69,8 +78,8 @@ func (a *agent) Start(ctx context.Context) {
 		a.runEdits,
 		a.runVariations,
 	} {
-		r := run
-		go func() {
+		go func(r func(context.Context) error) {
+			timer := time.NewTimer(a.pollingInterval)
 			for {
 				if err := r(ctx); err != nil {
 					if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -79,12 +88,30 @@ func (a *agent) Start(ctx context.Context) {
 
 					select {
 					case <-ctx.Done():
+						// Ensure the timer channel is drained
+						if !timer.Stop() {
+							select {
+							case <-timer.C:
+							default:
+							}
+						}
 						return
-					case <-time.After(a.pollingInterval):
+					case <-timer.C:
+					case <-a.trigger.Triggered():
 					}
 				}
+
+				if !timer.Stop() {
+					// Ensure the timer channel is drained
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+
+				timer.Reset(a.pollingInterval)
 			}
-		}()
+		}(run)
 	}
 
 	// Start cleanup
@@ -97,7 +124,8 @@ func (a *agent) Start(ctx context.Context) {
 				new(db.CreateImageVariationRequest),
 				new(db.ImagesResponse),
 			}
-			cdb = a.db.WithContext(ctx)
+			cdb   = a.db.WithContext(ctx)
+			timer = time.NewTimer(cleanupInterval)
 		)
 		for {
 			slog.Debug("looking for expired image requests and responses")
@@ -108,9 +136,18 @@ func (a *agent) Start(ctx context.Context) {
 
 			select {
 			case <-ctx.Done():
+				// Ensure the timer channel is drained
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
 				return
-			case <-time.After(cleanupInterval):
+			case <-timer.C:
 			}
+
+			timer.Reset(cleanupInterval)
 		}
 	}()
 }

--- a/pkg/agents/image/variations.go
+++ b/pkg/agents/image/variations.go
@@ -119,5 +119,7 @@ func (a *agent) runVariations(ctx context.Context) error {
 		l.Error("failed to store image variation response", "err", err)
 	}
 
+	a.trigger.Ready(variationRequest.ID)
+
 	return nil
 }

--- a/pkg/trigger/noop.go
+++ b/pkg/trigger/noop.go
@@ -1,0 +1,20 @@
+package trigger
+
+// NewNoop creates a noop trigger, which returns nil for all channels.
+// Note that receiving or sending on these channels will block forever.
+// This means that all places where this is used will essentially have a polling implementation.
+func NewNoop() Trigger {
+	return &noop{}
+}
+
+type noop struct{}
+
+func (t *noop) Triggered() <-chan struct{} {
+	return nil
+}
+
+func (t *noop) Kick(string) chan struct{} {
+	return nil
+}
+
+func (t *noop) Ready(string) {}

--- a/pkg/trigger/trigger.go
+++ b/pkg/trigger/trigger.go
@@ -1,0 +1,63 @@
+package trigger
+
+import (
+	"sync"
+)
+
+type Trigger interface {
+	Kick(id string) chan struct{}
+	Triggered() <-chan struct{}
+	Ready(id string)
+}
+
+type trigger struct {
+	syncNow      chan struct{}
+	readySignals map[string]chan struct{}
+	lock         *sync.Mutex
+}
+
+func New() Trigger {
+	return &trigger{
+		syncNow:      make(chan struct{}),
+		readySignals: make(map[string]chan struct{}),
+		lock:         new(sync.Mutex),
+	}
+}
+
+// Kick will kick the chat completion runner to check for new requests.
+// If the runner is already running, then this will do nothing.
+// The returned channel will be closed when the runner has processed the request with the given ID.
+func (t *trigger) Kick(id string) chan struct{} {
+	t.lock.Lock()
+	ready, ok := t.readySignals[id]
+	if !ok {
+		ready = make(chan struct{})
+		t.readySignals[id] = ready
+	}
+	t.lock.Unlock()
+
+	// Since syncNow is unbuffered, then the default statement here will ensure that we only sync if we are not already
+	// expecting a sync.
+	select {
+	case t.syncNow <- struct{}{}:
+	default:
+	}
+
+	return ready
+}
+
+// Ready will close the channel for the given ID, if it exists, signaling the runner has processed the request.
+func (t *trigger) Ready(id string) {
+	t.lock.Lock()
+	ready, ok := t.readySignals[id]
+	if ok {
+		delete(t.readySignals, id)
+		close(ready)
+	}
+	t.lock.Unlock()
+}
+
+// Triggered will return a channel that will be sent on when a trigger is requested.
+func (t *trigger) Triggered() <-chan struct{} {
+	return t.syncNow
+}


### PR DESCRIPTION
This change introduces "triggers" which will allow the server to tell the various agents to check for new objects. The trigger includes a "ready" call which will tell the trigger-er that the corresponding object has been processed.