### PR TITLE
Run step stop cancel

### DIFF
--- a/pkg/db/ops.go
+++ b/pkg/db/ops.go
@@ -118,7 +118,7 @@ func CancelRun(db *gdb.DB, id string) (*Run, error) {
 		}
 
 		for _, runStep := range runSteps {
-			if err := tx.Model(runStep).Clauses(clause.Returning{}).Where("id = ?", runStep.ID).Updates(update).Error; err != nil {
+			if err := tx.Model(&runStep).Clauses(clause.Returning{}).Where("id = ?", runStep.ID).Updates(update).Error; err != nil {
 				return err
 			}
 


### PR DESCRIPTION
This change has three commits:
~1. `feat: add triggering to speed up job processing` is a different PR (https://github.com/gptscript-ai/clicky-chats/pull/82) and can be ignored here.~
2. `fix: stop processing of run step when it is canceled` is the bulk of the change: ensure that canceling a run will stop the processing of run steps.
3. `feat: run the run steps in their own goroutine` does what is says. I added it here based on our standup conversation.