### PR TITLE
Fix tool call func names

### DIFF
--- a/pkg/agents/agents.go
+++ b/pkg/agents/agents.go
@@ -21,7 +21,7 @@ import (
 	_ "github.com/gptscript-ai/gptscript/pkg/loader/github"
 )
 
-var emptyMessagesLimit = 500
+var emptyMessagesLimit = 5000
 
 func init() {
 	if limit, err := strconv.Atoi(os.Getenv("CLICKY_CHATS_EMPTY_MESSAGES_LIMIT")); err == nil {

--- a/pkg/cli/agent.go
+++ b/pkg/cli/agent.go
@@ -29,7 +29,7 @@ type Agent struct {
 	DefaultChatCompletionURL string `usage:"The default URL for the chat completion agent to use" default:"https://api.openai.com/v1/chat/completions" env:"CLICKY_CHATS_CHAT_COMPLETION_SERVER_URL"`
 	ModelsURL                string `usage:"The url for the to get the available models" default:"https://api.openai.com/v1/models" env:"CLICKY_CHATS_CHAT_COMPLETION_SERVER_URL"`
 
-	ToolRunnerBaseURL string `usage:"Tool runner base URL" default:"https://api.openai.com/v1" env:"CLICKY_CHATS_TOOL_RUNNER_BASE_URL"`
+	ToolRunnerBaseURL string `usage:"Tool runner base URL" default:"http://localhost:8080/v1" env:"CLICKY_CHATS_TOOL_RUNNER_BASE_URL"`
 
 	DefaultImagesURL string `usage:"The default base URL for the image agent to use" default:"https://api.openai.com/v1/images" env:"CLICKY_CHATS_IMAGES_SERVER_URL"`
 
@@ -37,7 +37,7 @@ type Agent struct {
 
 	DefaultAudioURL string `usage:"The default URL for the translation agent to use" default:"https://api.openai.com/v1/audio" env:"CLICKY_CHATS_AUDIO_SERVER_URL"`
 
-	APIURL      string `usage:"URL for API calls" default:"https://api.openai.com/v1/chat/completions" env:"CLICKY_CHATS_SERVER_URL"`
+	APIURL      string `usage:"URL for API calls" default:"http://localhost:8080/v1/chat/completions" env:"CLICKY_CHATS_SERVER_URL"`
 	ModelAPIKey string `usage:"API key for API calls" env:"CLICKY_CHATS_MODEL_API_KEY"`
 	AgentID     string `usage:"Agent ID to identify this agent" default:"my-agent" env:"CLICKY_CHATS_AGENT_ID"`
 

--- a/pkg/db/runstep.go
+++ b/pkg/db/runstep.go
@@ -326,7 +326,7 @@ func GetOutputForRunStepToolCall(item *openai.RunStepDetailsToolCallsObject_Tool
 			logs, err = tc.CodeInterpreter.Outputs[0].AsRunStepDetailsToolCallsCodeOutputLogsObject()
 		}
 		info.ID = tc.Id
-		info.Name = string(openai.RunStepDetailsToolCallsCodeObjectTypeCodeInterpreter)
+		info.Name = tools.GPTScriptToolNamePrefix + string(openai.RunStepDetailsToolCallsCodeObjectTypeCodeInterpreter)
 		info.Arguments = tc.CodeInterpreter.Input
 		info.Output = logs.Logs
 		return info, err
@@ -334,7 +334,7 @@ func GetOutputForRunStepToolCall(item *openai.RunStepDetailsToolCallsObject_Tool
 	if tc, err := item.AsRunStepDetailsToolCallsRetrievalObject(); err == nil && tc.Type == openai.RunStepDetailsToolCallsRetrievalObjectTypeRetrieval {
 		b, err := json.Marshal(tc.Retrieval)
 		info.ID = tc.Id
-		info.Name = string(openai.RunStepDetailsToolCallsRetrievalObjectTypeRetrieval)
+		info.Name = tools.GPTScriptToolNamePrefix + string(openai.RunStepDetailsToolCallsRetrievalObjectTypeRetrieval)
 		info.Arguments = string(b)
 		info.Output = ""
 		return info, err
@@ -375,7 +375,7 @@ func runStepFromGenericToolCallInfo(info GenericToolCallInfo) (*openai.RunStepDe
 			Output    *string `json:"output"`
 		}{
 			Arguments: info.Arguments,
-			Name:      name,
+			Name:      info.Name,
 			Output:    nil,
 		},
 		info.ID,


### PR DESCRIPTION
- **fix: use gptscript prefix in tool call func names**
- **chore: bump default empty message limit to 5000**
- **chore: default to clicky-chats api for agent chat completions**
