### PR TITLE
feat: track token usage for runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/invopop/yaml v0.2.0
 	github.com/oapi-codegen/nethttp-middleware v1.0.1
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/pkoukk/tiktoken-go v0.1.6
+	github.com/sashabaranov/go-openai v1.20.4
 	github.com/spf13/cobra v1.8.0
 	gorm.io/datatypes v1.2.0
 	gorm.io/driver/mysql v1.5.4
@@ -37,6 +39,7 @@ require (
 	github.com/bodgit/windows v1.0.0 // indirect
 	github.com/bombsimon/logrusr/v4 v4.0.0 // indirect
 	github.com/connesc/cipherio v0.2.1 // indirect
+	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
@@ -77,7 +80,6 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/samber/lo v1.38.1 // indirect
 	github.com/samber/slog-logrus v1.0.0 // indirect
-	github.com/sashabaranov/go-openai v1.20.4 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
 github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
@@ -236,6 +238,8 @@ github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
+github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/pkg/agents/toolrunner/tool_runner.go
+++ b/pkg/agents/toolrunner/tool_runner.go
@@ -237,7 +237,7 @@ func (a *agent) processToolRun(ctx context.Context, caster *broadcaster.Broadcas
 	envs := append(os.Environ(), runTool.EnvVars...)
 
 	gdb := a.db.WithContext(ctx)
-	runTool.Output, err = agents.RunTool(timeoutCtx, l, caster, gdb, opts, prg, envs, runTool.Input, "", runTool.ID)
+	runTool.Output, _, err = agents.RunTool(timeoutCtx, l, caster, gdb, opts, prg, envs, runTool.Input, "", runTool.ID)
 	if err != nil {
 		return fmt.Errorf("failed to run tool: %w", err)
 	}

--- a/pkg/agents/usage.go
+++ b/pkg/agents/usage.go
@@ -1,0 +1,157 @@
+package agents
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/gptscript-ai/gptscript/pkg/runner"
+	"github.com/gptscript-ai/gptscript/pkg/server"
+	"github.com/gptscript-ai/gptscript/pkg/types"
+	"github.com/pkoukk/tiktoken-go"
+	oai "github.com/sashabaranov/go-openai"
+)
+
+type Usage struct {
+	Model            string
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+}
+
+// SumUsage returns the sum of the given usages as a single usage.
+// Note: Run step completion usage assumes chat completion requests were made to a single model, however gptscript can
+// make requests to many different models over the course of a run_step, so producing a single summed usage is technically
+// incorrect but will have to do until we come up with something better.
+func SumUsage(usages []Usage) Usage {
+	var usage Usage
+	for _, u := range usages {
+		usage.PromptTokens += u.PromptTokens
+		usage.CompletionTokens += u.CompletionTokens
+		usage.TotalTokens += u.TotalTokens
+	}
+
+	return usage
+}
+
+// PromptTokens returns the total number of prompt tokens for a given OpenAI model and request.
+// An error is returned if counting isn't supported for the given model.
+func PromptTokens(model string, req *TokenRequest) (int, error) {
+	tkm, err := tiktoken.EncodingForModel(model)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get encoding for model %s: %w", model, err)
+	}
+
+	var fixedCost fixedTokenCost
+	switch model {
+	case "gpt-3.5-turbo-0613",
+		"gpt-3.5-turbo-16k-0613",
+		"gpt-4-0314",
+		"gpt-4-32k-0314",
+		"gpt-4-0613",
+		"gpt-4-32k-0613":
+		fixedCost.message = 3
+		fixedCost.name = 1
+	case "gpt-3.5-turbo-0301":
+		fixedCost.message = 4 // every message follows <|start|>{role/name}\n{content}<|end|>\n
+		fixedCost.name = -1   // if there's a name, the role is omitted
+	default:
+		if strings.Contains(model, "gpt-3.5-turbo") {
+			// gpt-3.5-turbo may update over time. Returning num tokens assuming gpt-3.5-turbo-0613.
+			return PromptTokens("gpt-3.5-turbo-0613", req)
+		}
+		if strings.Contains(model, "gpt-4") {
+			// gpt-4 may update over time. Returning num tokens assuming gpt-4-0613.
+			return PromptTokens("gpt-4-0613", req)
+		}
+
+		return 0, fmt.Errorf("token counting method for model %s is unknown", model)
+	}
+
+	count := func(s string) int {
+		return len(tkm.Encode(s, nil, nil))
+	}
+
+	// Sum prompt tokens from explicit messages
+	var tokens int
+	for _, msg := range req.Messages {
+		tokens += fixedCost.message
+		for _, s := range []string{msg.Content, msg.Role, msg.Name} {
+			tokens += count(s)
+		}
+		if msg.Name != "" {
+			tokens += fixedCost.name
+		}
+	}
+
+	// TODO(njhale): Sum prompt tokens from function definitions
+	// Note: According to https://community.openai.com/t/how-to-calculate-the-tokens-when-using-function-call/266573/6,
+	// tool definitions are transformed into system messages with an undocumented encoding scheme before being passed
+	// to the LLM. https://community.openai.com/t/how-to-calculate-the-tokens-when-using-function-call/266573/10 suggests
+	// a counting implementation based on reverse-engineering token counts for non-streaming requests with tool definitions.
+
+	return tokens, nil
+}
+
+type fixedTokenCost struct {
+	message int
+	name    int
+}
+
+type TokenRequest struct {
+	Messages []TokenMessage `json:"messages"`
+	// TODO(njhale): Support Tool definitions
+}
+
+type TokenMessage struct {
+	Name    string `json:"name"`
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	// TODO(njhale): Support tool calls
+}
+
+type usageSet map[string]Usage
+
+func (s usageSet) addTokens(event server.Event) error {
+	if event.Type != runner.EventTypeChat {
+		return nil
+	}
+
+	usage := s[event.ChatCompletionID]
+	if req, ok := (event.ChatRequest).(oai.ChatCompletionRequest); ok {
+		usage.Model = req.Model
+		treq, err := Transform[TokenRequest](req)
+		if err != nil {
+			return fmt.Errorf("failed to transform chat completion request to token request: %w", err)
+		}
+
+		tokens, err := PromptTokens(usage.Model, &treq)
+		if err != nil {
+			return fmt.Errorf("failed to count prompt tokens: %w", err)
+		}
+
+		usage.PromptTokens += tokens
+		usage.TotalTokens += tokens
+
+		s[event.ChatCompletionID] = usage
+
+		return nil
+	}
+
+	if msg, ok := (event.ChatResponse).(types.CompletionMessage); ok &&
+		msg.Role == types.CompletionMessageRoleTypeAssistant {
+		// TODO(njhale): Implement me!
+		slog.Warn("Received tool call", "call", fmt.Sprintf("%v", msg))
+	}
+
+	return nil
+}
+
+func (s usageSet) asSlice() []Usage {
+	var usages []Usage
+	for _, u := range s {
+		usages = append(usages, u)
+	}
+
+	return usages
+}

--- a/pkg/db/chatcompletionchunk.go
+++ b/pkg/db/chatcompletionchunk.go
@@ -11,9 +11,14 @@ type ChatCompletionResponseChunk struct {
 	Choices           datatypes.JSONSlice[ChunkChoice] `json:"choices"`
 	Model             string                           `json:"model"`
 	SystemFingerprint *string                          `json:"system_fingerprint,omitempty"`
+
 	// Not part of the public API
 	JobResponse `json:",inline"`
-	ResponseIdx int `json:"response_idx"`
+	ResponseIdx int                                         `json:"response_idx"`
+	Usage       datatypes.JSONType[*openai.CompletionUsage] `json:"usage,omitempty"`
+
+	// RunID is only set when the chunk is related to the run
+	RunID *string `json:"run_id,omitempty"`
 }
 
 func (c *ChatCompletionResponseChunk) IDPrefix() string {
@@ -47,6 +52,7 @@ func (c *ChatCompletionResponseChunk) FromPublic(obj any) error {
 	}
 
 	if o != nil && c != nil {
+		var usage datatypes.JSONType[*openai.CompletionUsage]
 		*c = ChatCompletionResponseChunk{
 			Base{
 				CreatedAt: o.Created,
@@ -57,6 +63,8 @@ func (c *ChatCompletionResponseChunk) FromPublic(obj any) error {
 			o.SystemFingerprint,
 			JobResponse{},
 			0,
+			usage,
+			nil,
 		}
 	}
 


### PR DESCRIPTION
Track token usage for all chat completion streams created behind the
scenes for each run.

To sidestep the lack of usage for streaming, token counts are estimated
by tokenizing all chat completion requests and response chunks for known
OpenAI models.

