### PR TITLE
change: update to support new knowledge retrieval api

### DIFF
--- a/pkg/knowledgebases/knowledgebases.go
+++ b/pkg/knowledgebases/knowledgebases.go
@@ -39,7 +39,7 @@ func (m *KnowledgeBaseManager) NewSharedKnowledgeBase(ctx context.Context) (stri
 }
 
 type CreateKnowledgeBaseRequest struct {
-	Name     string `json:"name"`
+	ID       string `json:"id"`
 	EmbedDim int    `json:"embed_dim"`
 }
 
@@ -52,7 +52,7 @@ func (m *KnowledgeBaseManager) CreateKnowledgeBase(ctx context.Context, id strin
 
 	url := m.KnowledgeRetrievalAPIURL + "/datasets/create"
 	payload := CreateKnowledgeBaseRequest{
-		Name:     id,
+		ID:       id,
 		EmbedDim: 0,
 	}
 
@@ -89,7 +89,7 @@ func (m *KnowledgeBaseManager) CreateKnowledgeBase(ctx context.Context, id strin
 		return "", err
 	}
 
-	return response.Name, nil
+	return response.ID, nil
 }
 
 func (m *KnowledgeBaseManager) DeleteKnowledgeBase(ctx context.Context, id string) error {

--- a/pkg/tools/builtin.go
+++ b/pkg/tools/builtin.go
@@ -10,7 +10,7 @@ var builtInFunctionNameToDefinition = map[string]ToolDefinition{
 	"internet_search":  {Link: "github.com/gptscript-ai/question-answerer/duckduckgo", Commit: "091e15cf90c34062ec189abefd84b92150c6725f"},
 	"site_browsing":    {Link: "github.com/gptscript-ai/browse-web-page", Commit: "9656ac56b96c94fef24e30dc39482a24e0af0cb7"},
 	"code_interpreter": {Link: "github.com/gptscript-ai/code-interpreter", Commit: "b784f26c82e1ea55fe8ead4f2d38b5ff2651bca7"},
-	"retrieval":        {Link: "github.com/gptscript-ai/knowledge-retrieval-api", Commit: "30235686c44f046ebf5aa50a12d921878bb6503d"},
+	"retrieval":        {Link: "github.com/gptscript-ai/knowledge", Commit: "6e36c0be14856c4d872c66bb2022197b4fc8fd72"},
 }
 
 type ToolDefinition struct {


### PR DESCRIPTION
Source at https://github.com/gptscript-ai/knowledge

The old, python-based knowledge-retrieval-api has been updated to also support the /v1 api root.